### PR TITLE
Added missing library inclusions for uint8_t, etc.

### DIFF
--- a/includes/CCSDSSpacePacket.hh
+++ b/includes/CCSDSSpacePacket.hh
@@ -15,6 +15,12 @@
 #include <iomanip>
 #include <sstream>
 
+#if (defined(__GXX_EXPERIMENTAL_CXX0X) || (__cplusplus >= 201103L))
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 /** @mainpage CCSDS SpacePacket Library
  * @section intro Introduction
  * CCSDS SpacePacket Library is a header-only C++ class library

--- a/includes/CCSDSSpacePacketException.hh
+++ b/includes/CCSDSSpacePacketException.hh
@@ -8,6 +8,11 @@
 #ifndef CCSDSSPACEPACKETEXCEPTION_HH_
 #define CCSDSSPACEPACKETEXCEPTION_HH_
 
+#if (defined(__GXX_EXPERIMENTAL_CXX0X) || (__cplusplus >= 201103L))
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 /** An exception class used by the CCSDSSpacePacket class.
  */

--- a/includes/CCSDSSpacePacketPrimaryHeader.hh
+++ b/includes/CCSDSSpacePacketPrimaryHeader.hh
@@ -14,6 +14,12 @@
 #include <iomanip>
 #include <iostream>
 
+#if (defined(__GXX_EXPERIMENTAL_CXX0X) || (__cplusplus >= 201103L))
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 class CCSDSSpacePacketPacketVersionNumber {
 public:
 	enum {

--- a/includes/CCSDSSpacePacketSecondaryHeader.hh
+++ b/includes/CCSDSSpacePacketSecondaryHeader.hh
@@ -14,6 +14,12 @@
 #include <iomanip>
 #include <iostream>
 
+#if (defined(__GXX_EXPERIMENTAL_CXX0X) || (__cplusplus >= 201103L))
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 #include "CCSDSSpacePacketException.hh"
 
 class CCSDSSpacePacketSecondaryHeaderType {


### PR DESCRIPTION
Added missing library inclusions for uint8_t, uint16_t, etc. types. 
<stdint.h> for C++99 and <cstdint> for C++11.

Library would not compile on GNU/Linux x86_64 without these.
